### PR TITLE
BasicBolt needs to call shared_initialize()

### DIFF
--- a/petrel/petrel/storm.py
+++ b/petrel/petrel/storm.py
@@ -382,8 +382,7 @@ class BasicBolt(Task):
         global MODE
         MODE = Bolt
         global ANCHOR_TUPLE
-        conf, context = initComponent()
-        self.initialize(conf, context)
+        self.shared_initialize()
         profiler = self.profiler
         try:
             while True:


### PR DESCRIPTION
This is a very small fix. The generic exception handler wasn't working with `BasicBolt`. `self.worker_port` wasn't being set which caused an error in `report_exception`.
