### PR TITLE
Adding virtualenv path as second argument to setup.sh script.

### DIFF
--- a/petrel/petrel/package.py
+++ b/petrel/petrel/package.py
@@ -249,7 +249,7 @@ if [[ "$unamestr" != 'Darwin' ]]; then
 
             easy_install petrel-*-py$PYVER.egg >>$VENV_LOG 2>&1
             if [ -f ./setup.sh ]; then
-                /bin/bash ./setup.sh $CREATE_VENV >>$VENV_LOG 2>&1
+                /bin/bash ./setup.sh $CREATE_VENV $VENV >>$VENV_LOG 2>&1
             fi
             if [ "$has_flock" -eq "0" ]
             then 
@@ -270,7 +270,7 @@ if [[ "$unamestr" != 'Darwin' ]]; then
             source $VENV/bin/activate >>$LOG 2>&1
             easy_install -U petrel-*-py$PYVER.egg >>$VENV_LOG 2>&1
             if [ -f ./setup.sh ]; then
-                /bin/bash ./setup.sh $CREATE_VENV >>$VENV_LOG 2>&1
+                /bin/bash ./setup.sh $CREATE_VENV $VENV >>$VENV_LOG 2>&1
             fi
             unlock
         fi


### PR DESCRIPTION
This is needed to be able to activate the virtualenv in order to properly install
packages into it.
